### PR TITLE
Add vet, shelter, campaign models to prisma

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -37,6 +37,9 @@ model User {
   isVerified       Boolean @default(false)
 
   projectMembers ProjectMember[]
+  vets           Vet[]
+  shelters       Shelter[]
+  petOwner       PetOwner?
 
   createdAt        DateTime  @default(now())
   updatedAt        DateTime  @updatedAt
@@ -67,6 +70,7 @@ model Investor {
   customSocials       Json?        @default("{\"links\":[]}")
   isActivated         Boolean      @default(true)
   investments         Investment[]
+  donor               Donor?
   createdAt           DateTime     @default(now())
   updatedAt           DateTime     @updatedAt
 }
@@ -234,4 +238,74 @@ model Fund {
   amount    Float    @default(0)
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+}
+
+model Vet {
+  id     Int  @id @default(autoincrement())
+  userId Int
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+}
+
+model Shelter {
+  id     Int  @id @default(autoincrement())
+  userId Int
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+}
+
+model PetOwner {
+  id     Int  @id @default(autoincrement())
+  userId Int  @unique
+
+  user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  campaigns Campaign[]
+}
+
+model Donor {
+  id         Int  @id @default(autoincrement())
+  investorId Int  @unique
+
+  investor Investor  @relation(fields: [investorId], references: [id], onDelete: Cascade)
+  donations Donation[]
+}
+
+model Campaign {
+  id                Int               @id @default(autoincrement())
+  title             String
+  description       String
+  goalAmount        Float
+  campaignType      CampaignType
+  petInfo           Json?
+  verificationStatus VerificationStatus @default(PENDING)
+  petOwnerId        Int
+  createdAt         DateTime           @default(now())
+  updatedAt         DateTime           @updatedAt
+
+  petOwner PetOwner @relation(fields: [petOwnerId], references: [id], onDelete: Cascade)
+  donations Donation[]
+}
+
+model Donation {
+  id         Int      @id @default(autoincrement())
+  amount     Float
+  donorId    Int
+  campaignId Int
+  createdAt  DateTime @default(now())
+
+  donor    Donor    @relation(fields: [donorId], references: [id], onDelete: Cascade)
+  campaign Campaign @relation(fields: [campaignId], references: [id], onDelete: Cascade)
+}
+
+enum CampaignType {
+  MEDICAL
+  RESCUE
+  FOOD
+  OTHER
+}
+
+enum VerificationStatus {
+  PENDING
+  APPROVED
+  REJECTED
 }


### PR DESCRIPTION
## Summary
- support additional user categories in Prisma schema
- introduce campaign and donation models
- run migration attempt (fails in this environment)

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: next not found)*
- `npx prisma migrate dev --name add_pet_models --create-only --skip-seed` *(fails: Can't reach database server)*

------
https://chatgpt.com/codex/tasks/task_e_685f82d98a6c832e8dad6bfe1994b08d