### PR TITLE
Add campaign verification workflow

### DIFF
--- a/app/admin/campaigns/page.tsx
+++ b/app/admin/campaigns/page.tsx
@@ -1,0 +1,12 @@
+import { AdminLayout } from "@/components/admin/admin-layout";
+import AdminCampaigns from "@/components/admin/admin-campaigns";
+
+export default function CampaignsPage() {
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <AdminLayout>
+        <AdminCampaigns />
+      </AdminLayout>
+    </div>
+  );
+}

--- a/app/api/campaigns/[id]/route.ts
+++ b/app/api/campaigns/[id]/route.ts
@@ -1,0 +1,41 @@
+import prisma from "@/lib/prisma";
+import { NextResponse } from "next/server";
+
+export async function PUT(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const id = Number(params.id);
+    if (isNaN(id)) {
+      return NextResponse.json({ error: "Invalid id" }, { status: 400 });
+    }
+    const body = await request.json();
+    const { title, description, live } = body;
+
+    const existing = await prisma.campaign.findUnique({ where: { id } });
+    if (!existing) {
+      return NextResponse.json({ error: "Campaign not found" }, { status: 404 });
+    }
+
+    if (live === true && !existing.verified) {
+      return NextResponse.json(
+        { error: "Campaign must be verified before going live" },
+        { status: 400 }
+      );
+    }
+
+    const updated = await prisma.campaign.update({
+      where: { id },
+      data: {
+        title,
+        description,
+        live,
+      },
+    });
+    return NextResponse.json(updated);
+  } catch (error) {
+    console.error("Error updating campaign:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/api/campaigns/[id]/verify/route.ts
+++ b/app/api/campaigns/[id]/verify/route.ts
@@ -1,0 +1,22 @@
+import prisma from "@/lib/prisma";
+import { NextResponse } from "next/server";
+
+export async function PUT(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const id = Number(params.id);
+    if (isNaN(id)) {
+      return NextResponse.json({ error: "Invalid id" }, { status: 400 });
+    }
+    const campaign = await prisma.campaign.update({
+      where: { id },
+      data: { verified: true },
+    });
+    return NextResponse.json(campaign);
+  } catch (error) {
+    console.error("Error verifying campaign:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/api/campaigns/route.ts
+++ b/app/api/campaigns/route.ts
@@ -1,0 +1,45 @@
+import prisma from "@/lib/prisma";
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+
+export async function GET() {
+  try {
+    const campaigns = await prisma.campaign.findMany({
+      include: { user: true },
+    });
+    return NextResponse.json(campaigns);
+  } catch (error) {
+    console.error("Error fetching campaigns:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    const userId = (session.user as { id?: string })?.id;
+    const body = await request.json();
+    const { title, description } = body;
+    if (!title || !description) {
+      return NextResponse.json(
+        { error: "Title and description required" },
+        { status: 400 }
+      );
+    }
+    const campaign = await prisma.campaign.create({
+      data: {
+        title,
+        description,
+        userId: Number(userId),
+      },
+    });
+    return NextResponse.json(campaign, { status: 201 });
+  } catch (error) {
+    console.error("Error creating campaign:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/components/admin/admin-campaigns.tsx
+++ b/components/admin/admin-campaigns.tsx
@@ -1,0 +1,58 @@
+"use client";
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+} from "@/components/ui/card";
+
+interface Campaign {
+  id: number;
+  title: string;
+  description: string;
+  verified: boolean;
+  live: boolean;
+}
+
+export default function AdminCampaigns() {
+  const [campaigns, setCampaigns] = useState<Campaign[]>([]);
+
+  useEffect(() => {
+    fetch("/api/campaigns")
+      .then((res) => res.json())
+      .then((data) => setCampaigns(data))
+      .catch((err) => console.error(err));
+  }, []);
+
+  async function verify(id: number) {
+    const res = await fetch(`/api/campaigns/${id}/verify`, { method: "PUT" });
+    if (res.ok) {
+      const updated = await res.json();
+      setCampaigns((prev) =>
+        prev.map((c) => (c.id === updated.id ? updated : c))
+      );
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-3xl font-bold">Campaigns</h1>
+      {campaigns.map((c) => (
+        <Card key={c.id}>
+          <CardHeader>
+            <CardTitle>{c.title}</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <p>{c.description}</p>
+            <p>Status: {c.verified ? "Verified" : "Pending"}</p>
+            {!c.verified && (
+              <Button onClick={() => verify(c.id)}>Approve</Button>
+            )}
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -235,3 +235,16 @@ model Fund {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 }
+
+model Campaign {
+  id          Int      @id @default(autoincrement())
+  title       String
+  description String
+  userId      Int
+  verified    Boolean  @default(false)
+  live        Boolean  @default(false)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  user User @relation(fields: [userId], references: [id])
+}


### PR DESCRIPTION
## Summary
- create `Campaign` model for managing campaigns
- expose campaign CRUD endpoints under `/api/campaigns`
- add admin UI for viewing and approving campaigns
- enforce verification before a campaign can be published

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f83ca7bf0832e938bb63c850e0310