### PR TITLE
Add payment integration

### DIFF
--- a/app/api/payments/create-session/route.ts
+++ b/app/api/payments/create-session/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createStripeSession, createPayPalOrder } from "@/lib/payments";
+
+export async function POST(req: NextRequest) {
+  const { amount, provider, metadata } = await req.json();
+
+  if (!amount || amount <= 0) {
+    return NextResponse.json({ error: "Invalid amount" }, { status: 400 });
+  }
+
+  if (provider === "paypal") {
+    const order = await createPayPalOrder(amount);
+    return NextResponse.json({ id: order.id, links: order.links });
+  }
+
+  const session = await createStripeSession(amount, metadata);
+  return NextResponse.json({ id: session.id, url: session.url });
+}

--- a/app/api/webhooks/paypal/route.ts
+++ b/app/api/webhooks/paypal/route.ts
@@ -1,0 +1,8 @@
+import { NextRequest, NextResponse } from "next/server";
+import { handlePayPalWebhook } from "@/lib/payments";
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  await handlePayPalWebhook(body);
+  return NextResponse.json({ received: true });
+}

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from "next/server";
+import Stripe from "stripe";
+import { handleStripeWebhook } from "@/lib/payments";
+
+export async function POST(req: NextRequest) {
+  const payload = await req.text();
+  const sig = req.headers.get("stripe-signature") || "";
+  const secret = process.env.STRIPE_WEBHOOK_SECRET || "";
+
+  let event: Stripe.Event;
+  try {
+    event = Stripe.webhooks.constructEvent(payload, sig, secret);
+  } catch (err) {
+    return NextResponse.json({ error: "Webhook Error" }, { status: 400 });
+  }
+
+  await handleStripeWebhook(event);
+  return NextResponse.json({ received: true });
+}

--- a/lib/payments.ts
+++ b/lib/payments.ts
@@ -1,0 +1,76 @@
+import Stripe from "stripe";
+import paypal from "@paypal/checkout-server-sdk";
+import prisma from "@/lib/prisma";
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || "", {
+  apiVersion: "2023-10-16",
+});
+
+const paypalClient = new paypal.core.PayPalHttpClient(
+  new paypal.core.SandboxEnvironment(
+    process.env.PAYPAL_CLIENT_ID || "",
+    process.env.PAYPAL_CLIENT_SECRET || ""
+  )
+);
+
+export async function createStripeSession(amount: number, metadata: object = {}) {
+  return stripe.checkout.sessions.create({
+    payment_method_types: ["card"],
+    line_items: [
+      {
+        price_data: {
+          currency: "usd",
+          unit_amount: Math.round(amount * 100),
+          product_data: { name: "Donation" },
+        },
+        quantity: 1,
+      },
+    ],
+    mode: "payment",
+    success_url: `${process.env.NEXT_PUBLIC_BASE_URL}/payment/success`,
+    cancel_url: `${process.env.NEXT_PUBLIC_BASE_URL}/payment/cancel`,
+    metadata,
+  });
+}
+
+export async function createPayPalOrder(amount: number) {
+  const request = new paypal.orders.OrdersCreateRequest();
+  request.requestBody({
+    intent: "CAPTURE",
+    purchase_units: [{ amount: { currency_code: "USD", value: amount.toFixed(2) } }],
+  });
+  const response = await paypalClient.execute(request);
+  return response.result;
+}
+
+export async function handleStripeWebhook(event: Stripe.Event) {
+  if (event.type === "checkout.session.completed") {
+    const session = event.data.object as Stripe.Checkout.Session;
+    await prisma.donation.create({
+      data: {
+        amount: session.amount_total ? session.amount_total / 100 : 0,
+        currency: session.currency || "usd",
+        paymentProvider: "stripe",
+        paymentId: session.id,
+        projectId: Number(session.metadata?.projectId || 0),
+        status: "escrow",
+      },
+    });
+  }
+}
+
+export async function handlePayPalWebhook(body: any) {
+  if (body.event_type === "CHECKOUT.ORDER.APPROVED") {
+    const resource = body.resource;
+    await prisma.donation.create({
+      data: {
+        amount: parseFloat(resource.purchase_units[0].amount.value),
+        currency: resource.purchase_units[0].amount.currency_code.toLowerCase(),
+        paymentProvider: "paypal",
+        paymentId: resource.id,
+        projectId: Number(resource.custom_id || 0),
+        status: "escrow",
+      },
+    });
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^5.0.1",
+        "@paypal/checkout-server-sdk": "^1.0.3",
         "@prisma/client": "^6.8.2",
         "@radix-ui/react-avatar": "^1.1.10",
         "@radix-ui/react-checkbox": "^1.3.2",
@@ -45,6 +46,7 @@
         "socket.io": "^4.8.1",
         "socket.io-client": "^4.8.1",
         "sonner": "^2.0.3",
+        "stripe": "^18.2.1",
         "tailwind-merge": "^3.3.0",
         "tailwindcss-animate": "^1.0.7",
         "vaul": "^1.1.2",
@@ -1520,6 +1522,28 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/@paypal/checkout-server-sdk": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@paypal/checkout-server-sdk/-/checkout-server-sdk-1.0.3.tgz",
+      "integrity": "sha512-UEdq8akEdMz0Vs4qoQFU2gMp8PpyE/HKyMwiZuK4vIWUKl8jfd1fWKjQN5cDFm9NkFUIp5U7h++rdMOVj9WMNA==",
+      "deprecated": "Package no longer supported. The author suggests using the @paypal/paypal-server-sdk package instead: https://www.npmjs.com/package/@paypal/paypal-server-sdk. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "SEE LICENSE IN https://github.com/paypal/Checkout-NodeJS-SDK/blob/master/LICENSE",
+      "dependencies": {
+        "@paypal/paypalhttp": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@paypal/paypalhttp": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@paypal/paypalhttp/-/paypalhttp-1.0.1.tgz",
+      "integrity": "sha512-DC7AHxTT7drF6dUi3YaFdPVuT15sIkpD5H2eHmdtFgxM4UanS1o1ZDfMhR9mpxd8o+X6pz2r+EZVRRq+n1cssQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@prisma/client": {
@@ -3956,7 +3980,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -7165,7 +7188,6 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7579,6 +7601,21 @@
       "engines": {
         "node": ">=0.6.0",
         "teleport": ">=0.2.0"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/queue-microtask": {
@@ -8065,7 +8102,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -8085,7 +8121,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -8102,7 +8137,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -8121,7 +8155,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -8465,6 +8498,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stripe": {
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-18.2.1.tgz",
+      "integrity": "sha512-GwB1B7WSwEBzW4dilgyJruUYhbGMscrwuyHsPUmSRKrGHZ5poSh2oU9XKdii5BFVJzXHn35geRvGJ6R8bYcp8w==",
+      "license": "MIT",
+      "dependencies": {
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      },
+      "peerDependencies": {
+        "@types/node": ">=12.x.x"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/styled-jsx": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.0.1",
+    "@paypal/checkout-server-sdk": "^1.0.3",
     "@prisma/client": "^6.8.2",
     "@radix-ui/react-avatar": "^1.1.10",
     "@radix-ui/react-checkbox": "^1.3.2",
@@ -51,6 +52,7 @@
     "socket.io": "^4.8.1",
     "socket.io-client": "^4.8.1",
     "sonner": "^2.0.3",
+    "stripe": "^18.2.1",
     "tailwind-merge": "^3.3.0",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^1.1.2",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -95,6 +95,7 @@ model Project {
   milestones       Milestone[]
   documents        Documents[]
   message          Message[]
+  donations        Donation[]
   admin            Admin?            @relation(fields: [adminId], references: [id], onDelete: SetNull, onUpdate: Cascade)
   category         Category?         @relation(fields: [categoryId], references: [id])
   categoryId       Int?
@@ -234,4 +235,18 @@ model Fund {
   amount    Float    @default(0)
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+}
+
+model Donation {
+  id            Int      @id @default(autoincrement())
+  amount        Float
+  currency      String   @default("usd")
+  paymentProvider String
+  paymentId     String   @unique
+  projectId     Int
+  status        String   @default("escrow")
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+
+  project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
 }


### PR DESCRIPTION
## Summary
- include Stripe and PayPal SDKs
- introduce payments service for creating sessions and handling webhooks
- add donation model and expose payment related API routes

## Testing
- `npx prisma generate`

------
https://chatgpt.com/codex/tasks/task_e_685f8503dc68832e96ce2af885a4ba60