### PR TITLE
Add campaign detail page with comment system

### DIFF
--- a/app/api/comments/route.ts
+++ b/app/api/comments/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+
+export async function GET(req: NextRequest) {
+  try {
+    const projectId = req.nextUrl.searchParams.get("projectId");
+    if (!projectId) {
+      return NextResponse.json({ error: "Project ID is required" }, { status: 400 });
+    }
+    const comments = await prisma.comment.findMany({
+      where: { projectId: Number(projectId) },
+      orderBy: { createdAt: "asc" },
+      include: {
+        user: { select: { id: true, name: true, profile_picture: true } },
+        investor: { select: { id: true, name: true, profile_picture: true } },
+      },
+    });
+    return NextResponse.json(comments);
+  } catch (error) {
+    console.error("Error fetching comments:", error);
+    return NextResponse.json({ error: "Failed to fetch comments" }, { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session || !session.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    const { projectId, content } = await req.json();
+    if (!projectId || !content) {
+      return NextResponse.json({ error: "Missing fields" }, { status: 400 });
+    }
+    const userId = Number((session.user as { id?: string }).id);
+    const role = (session.user as { role?: string }).role;
+    const data: any = {
+      content,
+      projectId: Number(projectId),
+      commenterType: role === "investor" ? "investor" : "user",
+    };
+    if (role === "investor") {
+      data.investorId = userId;
+    } else {
+      data.userId = userId;
+    }
+    const comment = await prisma.comment.create({ data });
+    return NextResponse.json(comment, { status: 201 });
+  } catch (error) {
+    console.error("Error creating comment:", error);
+    return NextResponse.json({ error: "Failed to create comment" }, { status: 500 });
+  }
+}

--- a/app/campaigns/[id]/page.tsx
+++ b/app/campaigns/[id]/page.tsx
@@ -1,0 +1,12 @@
+"use client";
+import { useParams } from "next/navigation";
+import CampaignDetails from "@/components/shared/campaign-details";
+
+export default function CampaignPage() {
+  const { id } = useParams();
+  return (
+    <div className="min-h-screen p-6">
+      <CampaignDetails id={id as string} />
+    </div>
+  );
+}

--- a/components/shared/campaign-details.tsx
+++ b/components/shared/campaign-details.tsx
@@ -1,0 +1,55 @@
+"use client";
+import { useEffect } from "react";
+import { useCommonStore } from "@/store/useCommonStore";
+import { Card, CardContent, CardHeader, CardImage, CardTitle } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+import Comments from "./comments";
+import safeUrl from "@/lib/safeURL";
+
+export default function CampaignDetails({ id }: { id: string }) {
+  const { startups, fetchStartups, isLoading } = useCommonStore();
+  useEffect(() => {
+    if (!startups) {
+      fetchStartups();
+    }
+  }, [startups, fetchStartups]);
+
+  const campaign = startups?.find((s) => String(s.id) === id);
+  if (isLoading || !campaign) return <div>Loading...</div>;
+  const progress =
+    (Number.parseInt((campaign.raised_amount?.toString() || "0").replace(/[^0-9]/g, "")) /
+      Number.parseInt((campaign.budget?.toString() || "1").replace(/[^0-9]/g, ""))) * 100;
+
+  return (
+    <div className="space-y-6">
+      <div className="relative rounded-xl overflow-hidden">
+        <CardImage src={safeUrl(campaign.cover_image) || "/placeholder.svg"} alt="cover" className="w-full h-60" />
+      </div>
+      <Card>
+        <CardHeader>
+          <CardTitle>{campaign.title}</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div>{campaign.description}</div>
+          <div className="space-y-2">
+            <Progress value={progress} className="h-2" />
+            <div className="text-sm text-muted-foreground">{progress.toFixed(0)}% funded</div>
+          </div>
+        </CardContent>
+      </Card>
+      <div className="flex gap-4">
+        <a
+          href={`https://www.instagram.com/?url=${encodeURIComponent(typeof window !== 'undefined' ? window.location.href : '')}`}
+          target="_blank" rel="noopener noreferrer" className="text-sm underline">
+          Share on Instagram
+        </a>
+        <a
+          href={`https://www.tiktok.com/share?url=${encodeURIComponent(typeof window !== 'undefined' ? window.location.href : '')}`}
+          target="_blank" rel="noopener noreferrer" className="text-sm underline">
+          Share on TikTok
+        </a>
+      </div>
+      <Comments projectId={id} />
+    </div>
+  );
+}

--- a/components/shared/comments.tsx
+++ b/components/shared/comments.tsx
@@ -1,0 +1,77 @@
+"use client";
+import { useEffect, useState } from "react";
+import axios from "axios";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import { useSession } from "next-auth/react";
+
+interface Comment {
+  id: number;
+  content: string;
+  createdAt: string;
+  user?: { id: number; name: string; profile_picture: string | null };
+  investor?: { id: number; name: string; profile_picture: string | null };
+}
+
+export default function Comments({ projectId }: { projectId: string }) {
+  const { data: session } = useSession();
+  const [comments, setComments] = useState<Comment[]>([]);
+  const [content, setContent] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const fetchComments = async () => {
+      try {
+        const res = await axios.get(`/api/comments?projectId=${projectId}`);
+        setComments(res.data);
+      } catch (err) {
+        console.error("Failed to fetch comments", err);
+      }
+    };
+    fetchComments();
+  }, [projectId]);
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!content.trim()) return;
+    setLoading(true);
+    try {
+      await axios.post("/api/comments", { projectId, content });
+      const res = await axios.get(`/api/comments?projectId=${projectId}`);
+      setComments(res.data);
+      setContent("");
+    } catch (err) {
+      console.error("Failed to post comment", err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <h3 className="text-lg font-semibold">Comments</h3>
+      <div className="space-y-3">
+        {comments.map((c) => (
+          <div key={c.id} className="border rounded-md p-3 space-y-1">
+            <div className="text-sm font-medium">
+              {c.user?.name || c.investor?.name || "Anonymous"}
+            </div>
+            <div className="text-sm">{c.content}</div>
+          </div>
+        ))}
+      </div>
+      {session && (
+        <form onSubmit={submit} className="space-y-2">
+          <Textarea
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            placeholder="Add a comment..."
+          />
+          <Button type="submit" disabled={loading}>
+            Post
+          </Button>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -41,6 +41,7 @@ model User {
   createdAt        DateTime  @default(now())
   updatedAt        DateTime  @updatedAt
   Project          Project[]
+  comments         Comment[]
   sentMessages     Message[] @relation("SentMessages")
   receivedMessages Message[] @relation("ReceivedMessages")
 }
@@ -67,6 +68,7 @@ model Investor {
   customSocials       Json?        @default("{\"links\":[]}")
   isActivated         Boolean      @default(true)
   investments         Investment[]
+  comments            Comment[]
   createdAt           DateTime     @default(now())
   updatedAt           DateTime     @updatedAt
 }
@@ -95,6 +97,7 @@ model Project {
   milestones       Milestone[]
   documents        Documents[]
   message          Message[]
+  comments         Comment[]
   admin            Admin?            @relation(fields: [adminId], references: [id], onDelete: SetNull, onUpdate: Cascade)
   category         Category?         @relation(fields: [categoryId], references: [id])
   categoryId       Int?
@@ -234,4 +237,24 @@ model Fund {
   amount    Float    @default(0)
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+}
+
+model Comment {
+  id            Int      @id @default(autoincrement())
+  content       String
+  projectId     Int
+  commenterType CommentRole
+  userId        Int?
+  investorId    Int?
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+
+  project  Project  @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  user     User?    @relation(fields: [userId], references: [id], onDelete: SetNull)
+  investor Investor? @relation(fields: [investorId], references: [id], onDelete: SetNull)
+}
+
+enum CommentRole {
+  user
+  investor
 }


### PR DESCRIPTION
## Summary
- add Comment model and enum in Prisma schema
- create `/api/comments` API to fetch and post comments
- build `Comments` component
- build `CampaignDetails` page component with share links
- expose dynamic route `/campaigns/[id]` for campaign details

## Testing
- `npx prisma generate`
- `npm run lint` *(fails: compat.rules is not a function)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685f861551a8832eb5490dd39f4c01d0