### PR TITLE
Add badge, grant, analytics scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,10 +127,13 @@ npx prisma generate && npx prisma migrate deploy && npx prisma db seed
 ---
 
 ## ✅ Future Roadmap
+- 🎖️ User badges and achievements
+- 🎯 Grant matching for projects
+- 📈 Built-in analytics tracking
 
 - 📊 Admin dashboard analytics
     
-- 📱 Mobile-first PWA support
+- 📱 Mobile companion via React Native or PWA (see `docs/mobile-companion.md`)
     
 - 📩 Email/SMS notifications for milestone approvals
     

--- a/app/api/vet/verify/route.ts
+++ b/app/api/vet/verify/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const { vetId, data } = body;
+
+    if (!vetId) {
+      return NextResponse.json({ error: "vetId is required" }, { status: 400 });
+    }
+
+    // Placeholder for third-party verification logic
+    // Example: await externalVetService.verify(vetId, data);
+
+    return NextResponse.json(
+      { success: true, message: "Verification request queued" },
+      { status: 200 }
+    );
+  } catch (error) {
+    console.error("/api/vet/verify error:", error);
+    return NextResponse.json({ error: "Verification failed" }, { status: 500 });
+  }
+}

--- a/docs/mobile-companion.md
+++ b/docs/mobile-companion.md
@@ -1,0 +1,8 @@
+# Mobile Companion Options
+
+This project can be extended with a lightweight mobile companion. Two viable approaches are:
+
+1. **React Native app** – share business logic with the Next.js codebase while delivering a native look and feel.
+2. **Next.js Progressive Web App** – use the existing project and add service workers and manifest files for installability.
+
+Push notifications can be delivered via services like Firebase Cloud Messaging. These notifications keep users informed about milestone updates, new messages, or badge awards.

--- a/docs/third-party-api.md
+++ b/docs/third-party-api.md
@@ -1,0 +1,7 @@
+# Third-Party Integrations
+
+The application exposes endpoints under `/api` for integration with external services. A sample verification endpoint is provided below.
+
+## `POST /api/vet/verify`
+
+Send verification details for a vet or veterinary clinic. The request body should include a `vetId` and any additional `data` required by the third-party service. The endpoint currently returns a placeholder response but can be extended to call external APIs.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,11 +38,13 @@ model User {
 
   projectMembers ProjectMember[]
 
-  createdAt        DateTime  @default(now())
-  updatedAt        DateTime  @updatedAt
+  createdAt        DateTime         @default(now())
+  updatedAt        DateTime         @updatedAt
   Project          Project[]
-  sentMessages     Message[] @relation("SentMessages")
-  receivedMessages Message[] @relation("ReceivedMessages")
+  sentMessages     Message[]        @relation("SentMessages")
+  receivedMessages Message[]        @relation("ReceivedMessages")
+  UserBadge        UserBadge[]
+  AnalyticsEvent   AnalyticsEvent[]
 }
 
 model Investor {
@@ -98,6 +100,7 @@ model Project {
   admin            Admin?            @relation(fields: [adminId], references: [id], onDelete: SetNull, onUpdate: Cascade)
   category         Category?         @relation(fields: [categoryId], references: [id])
   categoryId       Int?
+  GrantMatch       GrantMatch[]
 }
 
 model ProjectMember {
@@ -132,7 +135,7 @@ model Investment {
   createdAt  DateTime @default(now())
   updatedAt  DateTime @default(now())
 
-  investor Investor  @relation(fields: [investorId], references: [id])
+  investor Investor @relation(fields: [investorId], references: [id])
 }
 
 model Milestone {
@@ -225,7 +228,7 @@ model Category {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  projects   Project[]
+  projects Project[]
 }
 
 model Fund {
@@ -234,4 +237,63 @@ model Fund {
   amount    Float    @default(0)
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+}
+
+model Badge {
+  id          Int      @id @default(autoincrement())
+  name        String   @unique
+  description String?
+  icon        String?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  userBadges UserBadge[]
+}
+
+model UserBadge {
+  id        Int      @id @default(autoincrement())
+  userId    Int
+  badgeId   Int
+  awardedAt DateTime @default(now())
+
+  user  User  @relation(fields: [userId], references: [id], onDelete: Cascade)
+  badge Badge @relation(fields: [badgeId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, badgeId])
+}
+
+model Grant {
+  id          Int      @id @default(autoincrement())
+  name        String
+  description String?
+  provider    String?
+  amount      Float
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  matches GrantMatch[]
+}
+
+model GrantMatch {
+  id        Int      @id @default(autoincrement())
+  projectId Int
+  grantId   Int
+  status    String   @default("pending")
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  grant   Grant   @relation(fields: [grantId], references: [id], onDelete: Cascade)
+
+  @@unique([projectId, grantId])
+}
+
+model AnalyticsEvent {
+  id        Int      @id @default(autoincrement())
+  userId    Int?
+  event     String
+  data      Json?
+  createdAt DateTime @default(now())
+
+  user User? @relation(fields: [userId], references: [id], onDelete: SetNull)
 }


### PR DESCRIPTION
## Summary
- sketch out models for badges, grant matching and analytics
- create `/api/vet/verify` placeholder endpoint for third-party integrations
- add docs for mobile companion ideas and integration API
- update roadmap with badges, grants and analytics

## Testing
- `npm run lint` *(fails: compat.rules is not a function)*
- `npm run build` *(fails: DATABASE_URL missing)*

------
https://chatgpt.com/codex/tasks/task_e_685f862a84b8832e9aa6e08430cd8648