### PR TITLE
Update UI branding to Happie

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
-# 🚀 Fundit – Empowering Student Entrepreneurs Through Crowdfunding
+# 🚀 Happie – Your Mental Wellness Companion
 
-**Fundit** is a full-stack crowdfunding platform built to connect aspiring **student entrepreneurs** with **impact-driven investors**. It creates a secure, milestone-based funding environment where students can turn startup ideas into reality, and investors can support innovation while earning passive returns.
+**Happie** is a full-stack platform focused on mental wellness. It helps students connect with supportive resources and enables investors to fund well-being initiatives.
 
 ---
 
@@ -122,7 +122,7 @@ npx prisma generate && npx prisma migrate deploy && npx prisma db seed
 
 ## 🚀 Live Demo 
 
-🔗 **Live Site:** [Live](https://fundit.mutiurrahman.com/)  
+🔗 **Live Site:** [Live](https://happie.example.com/)
 🎥 **Detailed Video:** [YouTube](https://www.youtube.com/watch?v=AvoooD7cLzQ)
 ---
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,9 +5,9 @@ import { Toaster } from "react-hot-toast";
 import { SessionProviderWrapper } from "@/components/providers/session-provider";
 import Project from "@/components/root/Project";
 export const metadata: Metadata = {
-  title: "Fundit",
+  title: "Happie",
   description:
-    "A platform for student founders to connect with investors and bring their ideas to life",
+    "A platform for student wellness, connecting students with helpful resources and supportive investors",
 };
 
 export default function RootLayout({

--- a/components/admin/admin-layout.tsx
+++ b/components/admin/admin-layout.tsx
@@ -267,7 +267,7 @@ export function AdminLayout({ children }: AdminLayoutProps) {
                   <div className="h-12 w-full flex items-center justify-center overflow-hidden">
                     <Image
                       src="/logo_light.png"
-                      alt="logo"
+                      alt="Happie logo"
                       height={32}
                       width={80}
                       style={{ objectFit: "contain" }}
@@ -321,7 +321,7 @@ export function AdminLayout({ children }: AdminLayoutProps) {
                   <div className="h-12 w-full flex items-center justify-center overflow-hidden">
                     <Image
                       src="/logo_light.png"
-                      alt="logo"
+                      alt="Happie logo"
                       height={32}
                       width={80}
                       style={{ objectFit: "contain" }}

--- a/components/home/home-footer.tsx
+++ b/components/home/home-footer.tsx
@@ -18,7 +18,7 @@ export function HomeFooter() {
           <div className="lg:col-span-1">
             <Link href="/" className="flex items-center">
               <span className="text-xl sm:text-2xl font-bold text-primary">
-                FundIt
+                Happie
               </span>
             </Link>
             <p className="mt-4 text-sm text-secondary">
@@ -139,13 +139,13 @@ export function HomeFooter() {
               </li>
               <li className="flex items-center">
                 <Mail className="h-5 w-5 text-primary mr-2" />
-                <span className="text-secondary">info@FundIt.com</span>
+                <span className="text-secondary">info@Happie.com</span>
               </li>
             </ul>
           </div>
         </div>
         <div className="border-t border-border mt-8 sm:mt-10 pt-6 text-center text-sm text-secondary">
-          <p>© {new Date().getFullYear()} FundIt. All rights reserved.</p>
+          <p>© {new Date().getFullYear()} Happie. All rights reserved.</p>
         </div>
       </div>
     </footer>

--- a/components/home/home-hero.tsx
+++ b/components/home/home-hero.tsx
@@ -115,7 +115,7 @@ export function HomeHero() {
             className="text-lg lg:text-xl xl:text-xl 2xl:text-2xl text-muted-foreground"
             variants={fadeInLeft}
           >
-            FundIt empowers student entrepreneurs to showcase their ideas and
+            Happie empowers student entrepreneurs to showcase their ideas and
             connect with investors who believe in their vision.
           </motion.p>
 

--- a/components/home/home-navbar.tsx
+++ b/components/home/home-navbar.tsx
@@ -38,7 +38,7 @@ export function HomeNavbar() {
       <div className="container mx-auto flex h-16 items-center justify-between px-4 sm:px-6">
         {/* Logo */}
         <Link href="/" className="flex items-center gap-2 group">
-          <Image src="/logo_light.png" alt="logo" height={135} width={135} />
+          <Image src="/logo_light.png" alt="Happie logo" height={135} width={135} />
         </Link>
 
         {/* Desktop Navigation */}

--- a/components/investor/investor-layout.tsx
+++ b/components/investor/investor-layout.tsx
@@ -210,7 +210,7 @@ export function InvestorLayout({ children }: InvestorLayoutProps) {
                   <div className="h-12 w-full flex items-center justify-center overflow-hidden">
                     <Image
                       src="/logo_light.png"
-                      alt="logo"
+                      alt="Happie logo"
                       height={32}
                       width={80}
                       style={{ objectFit: "contain" }}
@@ -281,7 +281,7 @@ export function InvestorLayout({ children }: InvestorLayoutProps) {
                   <div className="h-12 w-full flex items-center justify-center overflow-hidden">
                     <Image
                       src="/logo_light.png"
-                      alt="logo"
+                      alt="Happie logo"
                       height={32}
                       width={80}
                       style={{ objectFit: "contain" }}

--- a/components/root/about.tsx
+++ b/components/root/about.tsx
@@ -316,7 +316,7 @@ export function AboutComponent() {
                 />
               </h2>
               <p className="text-xl text-foreground/70 max-w-2xl mx-auto">
-                FundIt operates on a simple but effective model that benefits
+                Happie operates on a simple but effective model that benefits
                 both student entrepreneurs and investors.
               </p>
             </motion.div>
@@ -413,7 +413,7 @@ export function AboutComponent() {
                 />
               </h2>
               <p className="text-xl text-foreground/70 max-w-2xl mx-auto">
-                The passionate individuals behind FundIt, dedicated to
+                The passionate individuals behind Happie, dedicated to
                 empowering student entrepreneurs.
               </p>
             </motion.div>
@@ -489,7 +489,7 @@ export function AboutComponent() {
               </h2>
               <p className="text-xl text-foreground/70 max-w-2xl mx-auto">
                 Hear from students and investors who've found success through
-                FundIt.
+                Happie.
               </p>
             </motion.div>
 

--- a/components/root/contact.tsx
+++ b/components/root/contact.tsx
@@ -32,15 +32,15 @@ const HERO_DATA = {
   badge: "Get in Touch",
   title: "We'd Love to Hear from You",
   description:
-    "Have questions about FundIt? Looking for support? Or just want to share your feedback? We're here to help.",
+    "Have questions about Happie? Looking for support? Or just want to share your feedback? We're here to help.",
 };
 
 const CONTACT_INFO = [
   {
     icon: Mail,
     title: "Email Us",
-    detail: "contact@FundIt.com",
-    href: "mailto:contact@FundIt.com",
+    detail: "contact@Happie.com",
+    href: "mailto:contact@Happie.com",
   },
   {
     icon: Phone,
@@ -70,14 +70,14 @@ const FAQ_DATA = [
       "Registration is simple! Click on the 'Sign Up' button, select 'Student', and follow the guided process to create your account and set up your startup profile.",
   },
   {
-    question: "What type of startups can join FundIt?",
+    question: "What type of startups can join Happie?",
     answer:
       "We welcome student-led startups from all industries and sectors. Whether you're working on tech, sustainability, healthcare, or creative projects, our platform is designed to support you.",
   },
   {
     question: "How are investments structured?",
     answer:
-      "FundIt uses a milestone-based investment approach. Funds are released as entrepreneurs complete predefined milestones, providing accountability for founders and security for investors.",
+      "Happie uses a milestone-based investment approach. Funds are released as entrepreneurs complete predefined milestones, providing accountability for founders and security for investors.",
   },
   {
     question: "Can I invest in multiple startups?",
@@ -114,7 +114,7 @@ const FORM_FIELDS = [
 ];
 
 const CTA_DATA = {
-  title: "Ready to Join the FundIt Community?",
+  title: "Ready to Join the Happie Community?",
   description:
     "Whether you're a student with a brilliant idea or an investor looking to support the next generation of innovators, we're here to connect you.",
   buttons: [
@@ -557,7 +557,7 @@ export function ContactComponent() {
                 />
               </h2>
               <p className="text-muted-foreground max-w-xl mx-auto text-sm md:text-base">
-                Find answers to common questions about FundIt
+                Find answers to common questions about Happie
               </p>
             </motion.div>
 

--- a/components/udayee/udayee-layout.tsx
+++ b/components/udayee/udayee-layout.tsx
@@ -222,7 +222,7 @@ export function UdayeeLayout({ children }: UdayeeLayoutProps) {
                   <div className="h-12 w-full flex items-center justify-center overflow-hidden">
                     <Image
                       src="/logo_light.png"
-                      alt="logo"
+                      alt="Happie logo"
                       height={32}
                       width={80}
                       style={{ objectFit: "contain" }}
@@ -293,7 +293,7 @@ export function UdayeeLayout({ children }: UdayeeLayoutProps) {
                   <div className="h-12 w-full flex items-center justify-center overflow-hidden">
                     <Image
                       src="/logo_light.png"
-                      alt="logo"
+                      alt="Happie logo"
                       height={32}
                       width={80}
                       style={{ objectFit: "contain" }}

--- a/components/udayee/udayee-onboarding.tsx
+++ b/components/udayee/udayee-onboarding.tsx
@@ -219,7 +219,7 @@ export function UdayeeOnboarding() {
         JSON.stringify({
           email: formData.university_email,
           subject: 'UdayeeConnect Registration',
-          text: "<h2>Thank you for registering with FUndIt! Your account is being created and will be activated shortly. Please check your email for further instructions.</h2>",
+          text: "<h2>Thank you for registering with Happie! Your account is being created and will be activated shortly. Please check your email for further instructions.</h2>",
           // text: `<h2>This is your final notice. Your recent actions have been noted and are entirely unacceptable. If this behavior continues or is not immediately corrected, I will have no choice but to escalate the matter further—through all available channels.
           // Let this serve as a formal warning: I am prepared to take decisive action if this is not resolved at once.
           // You've been given more than enough time and opportunity to correct your course. This is your last chance to do so.</h2>`,
@@ -263,12 +263,12 @@ export function UdayeeOnboarding() {
             className="text-2xl font-bold"
             style={{ color: "var(--sidebar-primary)" }}
           >
-            {step === 1 && "Welcome to FundIt"}
+            {step === 1 && "Welcome to Happie"}
             {step === 2 && "Verify Your Identity"}
             {step === 3 && "Create Your Account"}
           </CardTitle>
           <CardDescription>
-            {step === 1 && "Let's get started with your FundIt journey"}
+            {step === 1 && "Let's get started with your Happie journey"}
             {step === 2 && "Upload your documents for verification"}
             {step === 3 && "Set up your account credentials"}
           </CardDescription>

--- a/constants/about.ts
+++ b/constants/about.ts
@@ -45,9 +45,9 @@ const slideInRight = {
 // Data Arrays and Objects
 const HERO_DATA = {
   badge: "Our Story",
-  title: "About FundIt",
+  title: "About Happie",
   description:
-    "FundIt bridges the gap between innovative student entrepreneurs and investors who believe in nurturing the next generation of changemakers.",
+    "Happie bridges the gap between innovative student entrepreneurs and investors who believe in nurturing the next generation of changemakers.",
 };
 
 const MISSION_VISION = [
@@ -61,7 +61,7 @@ const MISSION_VISION = [
     icon: Lightbulb,
     title: "Our Vision",
     description:
-      "We envision a future where student entrepreneurship is celebrated and supported, where innovative ideas from university campuses can easily find the backing they need to grow and make an impact. FundIt aims to be the bridge that connects promising student startups with investors who are looking to support the next generation of entrepreneurs.",
+      "We envision a future where student entrepreneurship is celebrated and supported, where innovative ideas from university campuses can easily find the backing they need to grow and make an impact. Happie aims to be the bridge that connects promising student startups with investors who are looking to support the next generation of entrepreneurs.",
   },
 ];
 
@@ -92,7 +92,7 @@ const HOW_IT_WORKS_STEPS = [
   {
     title: "Student Registration",
     description:
-      "Students register on FundIt and create profiles for their startup projects.",
+      "Students register on Happie and create profiles for their startup projects.",
   },
   {
     title: "Project Creation",
@@ -154,27 +154,27 @@ const TEAM_MEMBERS = [
 const TESTIMONIALS = [
   {
     quote:
-      "FundIt helped me turn my idea into a real business. The milestone-based funding approach gave me clear goals to work towards, and the investor I connected with has become an invaluable mentor.",
+      "Happie helped me turn my idea into a real business. The milestone-based funding approach gave me clear goals to work towards, and the investor I connected with has become an invaluable mentor.",
     name: "Tahmid Hassan",
     role: "Student Entrepreneur, BUET",
     project: "EcoSolutions",
   },
   {
     quote:
-      "As an investor, I appreciate the structured approach FundIt brings to student startups. The platform makes it easy to track progress and maintain clear communication with founders.",
+      "As an investor, I appreciate the structured approach Happie brings to student startups. The platform makes it easy to track progress and maintain clear communication with founders.",
     name: "Farzana Rahman",
     role: "Angel Investor",
   },
   {
     quote:
-      "Finding investors was my biggest challenge until I discovered FundIt. Now my healthcare app has the funding it needs to reach communities across Bangladesh.",
+      "Finding investors was my biggest challenge until I discovered Happie. Now my healthcare app has the funding it needs to reach communities across Bangladesh.",
     name: "Mahir Ahmed",
     role: "Student Entrepreneur, DMC",
     project: "MediConnect",
   },
   {
     quote:
-      "FundIt gives me access to creative, ambitious student founders who bring fresh perspectives to old problems. It's been rewarding both financially and personally.",
+      "Happie gives me access to creative, ambitious student founders who bring fresh perspectives to old problems. It's been rewarding both financially and personally.",
     name: "Nasreen Khan",
     role: "Tech Investor",
   },
@@ -183,7 +183,7 @@ const TESTIMONIALS = [
 const CTA_DATA = {
   title: "Ready to Join the Journey?",
   description:
-    "Whether you're a student entrepreneur with an innovative idea or an investor looking to support the next generation of startups, FundIt is the platform for you.",
+    "Whether you're a student entrepreneur with an innovative idea or an investor looking to support the next generation of startups, Happie is the platform for you.",
 };
 
 export {


### PR DESCRIPTION
## Summary
- replace FundIt branding with Happie across UI components
- adjust page descriptions and metadata for Happie
- update README to mention Happie and live demo link

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685f8a2699f8832e978a1112eeb416b5